### PR TITLE
[Finish #66487196] User gets warnings because the copy tool tries to LOG...

### DIFF
--- a/src/main/java/nl/topicus/mssql2monetdb/CopyTool.java
+++ b/src/main/java/nl/topicus/mssql2monetdb/CopyTool.java
@@ -29,7 +29,8 @@ public class CopyTool
 	 */
 	public static void main(String[] args)
 	{
-		LOG.info("Started MSSQL2MonetDB copy tool");
+		//the log files is not yet inistialized
+		System.out.println("Started MSSQL2MonetDB copy tool");
 
 		// run tool
 		(new CopyTool(new CopyToolConfig(args))).run();

--- a/src/main/java/nl/topicus/mssql2monetdb/CopyToolConfig.java
+++ b/src/main/java/nl/topicus/mssql2monetdb/CopyToolConfig.java
@@ -33,6 +33,7 @@ public class CopyToolConfig
 	public CopyToolConfig(String args[])
 	{
 		PropertyConfigurator.configure("log4j.properties");
+		LOG.info("Started logging of the MSSQL2MonetDB copy tool");
 
 		Options options = new Options();
 


### PR DESCRIPTION
... something before the logging is initialised with log4j.properties.
