### PR TITLE
Improve view creation in MonetDB

### DIFF
--- a/src/main/java/nl/topicus/mssql2monetdb/CopyToolConfig.java
+++ b/src/main/java/nl/topicus/mssql2monetdb/CopyToolConfig.java
@@ -826,8 +826,12 @@ public class CopyToolConfig
 			LOG.info("The following tables will be copied: ");
 			for (CopyTable table : tablesToCopy.values())
 			{
-				LOG.info("* " + table.getFromName() + " -> "
-					+ table.getCurrentTable().getNameWithPrefixes());
+				LOG.info(String.format(
+					"* %s -> %s.%s",
+					table.getFromName(),
+					table.getCurrentTable().getCopyTable().getSchema(),
+					table.getCurrentTable().getName()
+				));
 			}
 		}
 

--- a/src/main/java/nl/topicus/mssql2monetdb/util/MonetDBUtil.java
+++ b/src/main/java/nl/topicus/mssql2monetdb/util/MonetDBUtil.java
@@ -455,13 +455,14 @@ public class MonetDBUtil
 				+ monetDBTable.getToTableSql() + "' on MonetDB server...");
 			
 			// drop current table/view
-			boolean alreadyDropped = false;
-			while(tableOrViewExists(schema, name))
+			// we do this in a loop (of max 10) to ensure it really is dropped
+			// due to a possible bug in MonetDB whereby a view can exist multiple times
+			for(int i=0; i < 10 && tableOrViewExists(schema, name); i++)
 			{				
 				boolean isTable = isTable(schema, name);
 				
 				// display warning when table/view should have been dropped already
-				if (alreadyDropped)
+				if (i > 0)
 				{
 					if (isTable)
 						LOG.warn(String.format("Table %s still exists despite previous DROP. This should not be possible!", fullName));
@@ -491,9 +492,6 @@ public class MonetDBUtil
 					
 					throw e;
 				}
-				
-				// mark as dropped
-				alreadyDropped = true;
 			}
 			
 			// create new view

--- a/src/main/java/nl/topicus/mssql2monetdb/util/MonetDBUtil.java
+++ b/src/main/java/nl/topicus/mssql2monetdb/util/MonetDBUtil.java
@@ -1,5 +1,6 @@
 package nl.topicus.mssql2monetdb.util;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -38,16 +39,19 @@ public class MonetDBUtil
 	 */
 	public static boolean tableOrViewExists(String schema, String name) throws SQLException
 	{
-		try
+		try (Statement q =
+				CopyToolConnectionManager.getInstance().getMonetDbConnection().createStatement())
 		{
-			Statement q =
-				CopyToolConnectionManager.getInstance().getMonetDbConnection().createStatement();
 			ResultSet result =
 				q.executeQuery("SELECT name FROM sys.tables WHERE name = '" + name
 					+ "' AND schema_id = (SELECT id FROM sys.schemas WHERE name = '" + schema
 					+ "')");
+			
+			boolean ret = result.next();
+			result.close();
+			
 			// is true if rows exists, otherwise it is false
-			return result.next();
+			return ret;
 		}
 		catch (SQLException e)
 		{
@@ -59,20 +63,21 @@ public class MonetDBUtil
 
 	public static boolean isTable(String schema, String name) throws SQLException
 	{
-		try
+		try (	Statement q =
+				CopyToolConnectionManager.getInstance().getMonetDbConnection().createStatement())
 		{
-			Statement q =
-				CopyToolConnectionManager.getInstance().getMonetDbConnection().createStatement();
+		
 			ResultSet result =
 				q.executeQuery("SELECT query FROM sys.tables WHERE name = '" + name
 					+ "' and schema_id = (SELECT id from sys.schemas WHERE name = '" + schema
 					+ "')");
-			// move resultset to the actual result
-			if (!result.next())
-				return false;
+			
 			// the query column will be filled with a query when its a view, so if its
-			// null it will be a table
-			return result.getObject("query") == null;
+			// null it will be a table			
+			boolean isTable = (result.next() && result.getObject("query") == null);
+			result.close();
+			
+			return isTable;
 		}
 		catch (SQLException e)
 		{
@@ -396,10 +401,10 @@ public class MonetDBUtil
 		{
 			LOG.info("Dropping table or view '" + fullName + "' on MonetDB server...");
 			
-			try {
-				Statement stmt =
+			try (Statement stmt =
 					CopyToolConnectionManager.getInstance().getMonetDbConnection()
-						.createStatement();
+						.createStatement())
+			{
 				StringBuilder builder = new StringBuilder();
 				if (tableOrViewExists(schema, name))
 				{
@@ -435,44 +440,91 @@ public class MonetDBUtil
 	public static void dropAndRecreateViewForTable(String schema, String name,
 			MonetDBTable monetDBTable) throws SQLException
 	{
-		String fullName = schema + "." + name;
+		Connection conn = CopyToolConnectionManager.getInstance().getMonetDbConnection();
+		
+		// disable autocommit to work in a single transaction
+		boolean oldAutoCommit = conn.getAutoCommit();
+		conn.setAutoCommit(false);
+		
+		// make sure the referenced table exists 
 		if (monetDBTableExists(monetDBTable))
 		{
+			String fullName = schema + "." + name;
+			
 			LOG.info("Drop and recreate or create the view '" + fullName + "' for table '"
 				+ monetDBTable.getToTableSql() + "' on MonetDB server...");
-
-			try
-			{
-				Statement stmt =
-					CopyToolConnectionManager.getInstance().getMonetDbConnection()
-						.createStatement();
-				StringBuilder builder = new StringBuilder();
-				if (tableOrViewExists(schema, name))
+			
+			// drop current table/view
+			boolean alreadyDropped = false;
+			while(tableOrViewExists(schema, name))
+			{				
+				boolean isTable = isTable(schema, name);
+				
+				// display warning when table/view should have been dropped already
+				if (alreadyDropped)
 				{
-					// if its a table, drop the table
-					if (isTable(schema, name))
-						builder.append("DROP TABLE " + fullName + ";");
+					if (isTable)
+						LOG.warn(String.format("Table %s still exists despite previous DROP. This should not be possible!", fullName));
 					else
-						builder.append("DROP VIEW " + fullName + ";");
+						LOG.warn(String.format("View %s still exists despite previous DROP. This should not be possible!", fullName));
 				}
-
-				builder.append("CREATE VIEW " + fullName + " AS SELECT * FROM "
-					+ monetDBTable.getToTableSql());
-
-				stmt.execute(builder.toString());
+				
+				try (Statement stmt = conn.createStatement()) 
+				{
+					if (isTable)
+					{
+						LOG.info(String.format("Dropping existing table '%s'...", fullName));
+						stmt.execute("DROP TABLE " + fullName + ";");
+						LOG.info("Table dropped");
+					}
+					else
+					{
+						LOG.info(String.format("Dropping existing view '%s'...", fullName));
+						stmt.execute("DROP VIEW " + fullName + ";");
+						LOG.info("View dropped");
+					}
+				} catch (SQLException e) {
+					if (isTable)
+						LOG.error(String.format("Unable to drop table '%s'", fullName));
+					else
+						LOG.error(String.format("Unable to drop view '%s'", fullName));
+					
+					throw e;
+				}
+				
+				// mark as dropped
+				alreadyDropped = true;
 			}
-			catch (SQLException e)
+			
+			// create new view
+			try (Statement q = conn.createStatement())
 			{
-				LOG.error("Error dropping and recreating the view "
-					+ monetDBTable.getCopyTable().getToName(), e);
-				throw new RuntimeException(e);
+				q.execute(String.format(
+					"CREATE VIEW %s AS SELECT * FROM %s",
+					fullName,
+					monetDBTable.getToTableSql()
+				));
+			} catch (SQLException e) {
+				LOG.error(String.format(
+					"Unable to create view %s for table %s",
+					fullName,
+					monetDBTable.getToTableSql()
+				));				
+				
+				throw e;
 			}
+			
+			// commit transaction
+			conn.commit();
 			LOG.info("View '" + fullName + "' created");
 		}
 		else
 		{
-			LOG.info("View not created because the monetDBTable '" + monetDBTable.getToTableSql()
+			LOG.info("View not created because the MonetDB table '" + monetDBTable.getToTableSql()
 				+ "' does not exist");
 		}
+		
+		// restore previous autocommit mode
+		conn.setAutoCommit(oldAutoCommit);
 	}
 }


### PR DESCRIPTION
This PR is an attempt at improving the view-switching functionality.

Currently it appears that MonetDB has a bug that somehow allows multiple views with the same name to be created, resulting in a corrupted catalog and unpredictable query results. 

The changes in this PR will ensure that:
* the view-switch happens in a single transaction
* all previous views/tables are deleted
* better logging what happens during a view-switch

Additionally a report has been filed with the developers of MonetDB.